### PR TITLE
Can specify a url to load the geojson from

### DIFF
--- a/map.js
+++ b/map.js
@@ -321,8 +321,11 @@ if (loadUrlInput) {
 
     geojsonPathFromUrl = getGeojsonPathFromUrl();
     if (geojsonPathFromUrl) {
+        console.log("going to load geojson from " + geojsonPathFromUrl);
         loadUrlField.value = geojsonPathFromUrl;
         loadHostedGeojson(geojsonPathFromUrl);
+    } else {
+        console.log("no geojson url found");
     }
 }
 

--- a/map.js
+++ b/map.js
@@ -287,6 +287,12 @@ fileInput.addEventListener('change', function() {
     reader.readAsText(file);
 });
 
+// Load geojson from url
+const loadUrlInput = document.getElementById('loadFileFromUrl');
+loadUrlInput.addEventListener('click', function() {
+  loadHostedGeojson(document.getElementById('urlToLoadFrom').value);
+});
+
 const checkbox = document.getElementById('show-rat-runs');
 checkbox.checked = false;
 checkbox.addEventListener('change', () => {

--- a/map.js
+++ b/map.js
@@ -263,6 +263,7 @@ function processGeojson(geojson) {
 }
 
 function loadHostedGeojson(geojsonFilename) {
+    updateLocationWithGeojsonPath(geojsonFilename);
     var xhr = new XMLHttpRequest();
     xhr.onreadystatechange = function() {
         if (xhr.readyState === 4) {
@@ -275,6 +276,23 @@ function loadHostedGeojson(geojsonFilename) {
     };
     xhr.open("GET", geojsonFilename);
     xhr.send();
+}
+
+const geojsonParamKey = "geojson";
+
+function updateLocationWithGeojsonPath(geojsonPath) {
+    var url = new URL(window.location.href);
+    url.searchParams.set(geojsonParamKey, encodeURI(geojsonPath));
+    window.history.replaceState(null, null, url);
+}
+
+function getGeojsonPathFromUrl() {
+    const params = new URL(window.location.href).searchParams;
+    if (params.has(geojsonParamKey)) {
+        return decodeURI(params.get(geojsonParamKey));
+    } else {
+        return null;
+    }
 }
 
 
@@ -296,9 +314,16 @@ const loadUrlInput = document.getElementById('loadFileFromUrl');
 
 // On the hardcoded plans, that field does not exist, so we have to check for its existence
 if (loadUrlInput) {
+    const loadUrlField = document.getElementById('urlToLoadFrom');
     loadUrlInput.addEventListener('click', function() {
-        loadHostedGeojson(document.getElementById('urlToLoadFrom').value);
+        loadHostedGeojson(loadUrlField.value);
     });
+
+    geojsonPathFromUrl = getGeojsonPathFromUrl();
+    if (geojsonPathFromUrl) {
+        loadUrlField.value = geojsonPathFromUrl;
+        loadHostedGeojson(geojsonPathFromUrl);
+    }
 }
 
 const checkbox = document.getElementById('show-rat-runs');

--- a/map.js
+++ b/map.js
@@ -265,8 +265,12 @@ function processGeojson(geojson) {
 function loadHostedGeojson(geojsonFilename) {
     var xhr = new XMLHttpRequest();
     xhr.onreadystatechange = function() {
-        if (xhr.readyState === 4 && xhr.status === 200) {
-            processGeojson(xhr.responseText);
+        if (xhr.readyState === 4) {
+            if (xhr.status === 200) {
+                processGeojson(xhr.responseText);
+            } else {
+                alert("impossible de charger le fichier " + geojsonFilename + ". Ca peut être dû notamment à une erreur dans le chemin du fichier, à une mauvaise connection, ou à une configuration CORS invalide du serveur distant");
+            }
         }
     };
     xhr.open("GET", geojsonFilename);

--- a/map.js
+++ b/map.js
@@ -293,9 +293,13 @@ fileInput.addEventListener('change', function() {
 
 // Load geojson from url
 const loadUrlInput = document.getElementById('loadFileFromUrl');
-loadUrlInput.addEventListener('click', function() {
-  loadHostedGeojson(document.getElementById('urlToLoadFrom').value);
-});
+
+// On the hardcoded plans, that field does not exist, so we have to check for its existence
+if (loadUrlInput) {
+    loadUrlInput.addEventListener('click', function() {
+        loadHostedGeojson(document.getElementById('urlToLoadFrom').value);
+    });
+}
 
 const checkbox = document.getElementById('show-rat-runs');
 checkbox.checked = false;

--- a/new.html
+++ b/new.html
@@ -13,8 +13,8 @@
       </div>
 
       <div>
-        <span>Ou charger un fichier depuis une url : </span><input type="url" id="urlToLoadFrom" placeholder="https://example.com/fichier.json"/>
-        <input type="button" value="Charger le fichier depuis l'url" id="loadFileFromUrl" />
+        <span>Charger un fichier : </span><input type="url" id="urlToLoadFrom" placeholder="https://example.com/fichier.json"/>
+        <input type="button" value="Depuis une url" id="loadFileFromUrl" />
       </div>
       <div>
         <input type="checkbox" id="show-rat-runs">

--- a/new.html
+++ b/new.html
@@ -8,7 +8,14 @@
   </head>
   <body>
       <div id="map" style="height: 900px; width: 100%;"></div>
-      <input type="file" id="fileInput">
+      <div>
+        Charger un fichier depuis le disque : <input type="file" id="fileInput">
+      </div>
+
+      <div>
+        <span>Ou charger un fichier depuis une url : </span><input type="url" id="urlToLoadFrom" placeholder="https://example.com/fichier.json"/>
+        <input type="button" value="Charger le fichier depuis l'url" id="loadFileFromUrl" />
+      </div>
       <div>
         <input type="checkbox" id="show-rat-runs">
         <label> Afficher les rat runs</label><br>


### PR DESCRIPTION
This pull requests:

* adds a field where the user can put the url to her geojson and load it on the fly
* adds that path in a URL parameter when a geojson is loaded
* loads the geojson from that url parameter if it is set

so in practice it means that it gives a way to easily share a (publicly available) geojson between users.

To see it in action: launch coplano with this code and then browse this URL: `http://<your-server>/new.html?geojson=https%3A%2F%2Fcocarto.com%2Fen%2Flayers%2F30a7c24c-dc1b-41f9-acf5-949b66de9e39.geojson%3Ftoken%3Dagsv6rp6ytpxmFjt` : you should see that it loads my geojson